### PR TITLE
lunaApiBase: Fix unused LSError variables

### DIFF
--- a/src/lunaApi/lunaApiBase.cpp
+++ b/src/lunaApi/lunaApiBase.cpp
@@ -75,7 +75,7 @@ void lunaApiBase::LSMessageReplyErrorInvalidParams(LSHandle *sh, LSMessage *msg)
     LSError lserror;
     LSErrorInit(&lserror);
 
-    bool retVal = LSMessageReply(sh, msg, "{\"returnValue\":false,\"errorText\":\"Invalid parameters.\"}", NULL);
+    bool retVal = LSMessageReply(sh, msg, "{\"returnValue\":false,\"errorText\":\"Invalid parameters.\"}", &lserror);
     if (!retVal) {
         LSErrorPrint(&lserror, stderr);
         LSErrorFree(&lserror);
@@ -86,7 +86,7 @@ void lunaApiBase::LSMessageReplyErrorBadJSON(LSHandle *sh, LSMessage *msg) {
     LSError lserror;
     LSErrorInit(&lserror);
 
-    bool retVal = LSMessageReply(sh, msg, "{\"returnValue\":false,\"errorText\":\"Malformed json.\"}", NULL);
+    bool retVal = LSMessageReply(sh, msg, "{\"returnValue\":false,\"errorText\":\"Malformed json.\"}", &lserror);
     if (!retVal) {
         LSErrorPrint(&lserror, stderr);
         LSErrorFree(&lserror);
@@ -100,9 +100,9 @@ void lunaApiBase::LSMessageReplySuccess(LSHandle *sh, LSMessage *msg, char *payl
     bool retVal;
 
     if (payload == NULL) {
-        retVal = LSMessageReply(sh, msg, "{\"returnValue\":true}", NULL);
+        retVal = LSMessageReply(sh, msg, "{\"returnValue\":true}", &lserror);
     } else {
-        retVal = LSMessageReply(sh, msg, payload, NULL);
+        retVal = LSMessageReply(sh, msg, payload, &lserror);
     }
 
     if (!retVal) {


### PR DESCRIPTION
Although each callback methods have intialized LSError variables,
they are not being used by luna-service methods.
It does not make sense and also unset variables are used
by LSErrorPrint, nobody knows what will happen in the way.

To fix it, each luna-service methods are having them as parameters.